### PR TITLE
[ADD] modal 컴포넌트 추가

### DIFF
--- a/src/components/Modal/Modal.style.ts
+++ b/src/components/Modal/Modal.style.ts
@@ -1,0 +1,70 @@
+import { Divider, IconButton } from '@class101/ui';
+import { styled } from 'styled-components';
+import { ModalSizeProps } from '../../types/components';
+
+export const CommLayer = styled.div`
+  position: fixed;
+  inset: 0px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background: rgba(0, 0, 0, 0.4);
+  overflow-y: auto;
+  z-index: 11000;
+  overscroll-behavior-y: contain;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+`;
+
+export const ModalContainer = styled.div<ModalSizeProps>`
+  position: relative;
+  padding: 10px;
+  width: ${props => props.width};
+  min-width: 350px;
+  border-radius: 10px;
+  background-color: #fff;
+  text-align: center;
+  box-sizing: border-box;
+`;
+
+export const HeaderLayer = styled.div`
+  margin: 20px 0 30px;
+`;
+export const ModalDivider = styled(Divider)`
+  margin-top: 15px;
+`;
+
+export const StyledIconButton = styled(IconButton)`
+  position: absolute;
+  top: 7px;
+  right: 5px;
+`;
+
+export const BodyLayer = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  max-height: 540px;
+  overflow-y: scroll;
+  box-sizing: border-box;
+`;
+
+export const BodyText = styled.p`
+  padding: 60px 0 35px;
+  font-size: 1rem;
+  line-height: 1.7;
+  white-space: pre-line;
+  word-break: break-all;
+`;
+
+export const FooterLayer = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 15px;
+  background: ${({ theme }) => theme.lightGray};
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.keyBlue};
+  }
+`;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,88 @@
+import { FC, useState } from 'react';
+import * as S from './Modal.style';
+import { ModalProps } from '../../types/components';
+import { ButtonColor, CloseIcon, Headline3 } from '@class101/ui';
+import { StyledButton } from '../../Styles/common.style';
+import { theme } from '../../Styles/theme';
+
+const Modal: FC<ModalProps> = ({
+  opener,
+  title,
+  contents,
+  successText,
+  cancelText,
+  modalWidth,
+  onSuccess,
+  onCancel
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleModal = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <>
+      <div onClick={handleModal}>{opener}</div>
+      {isOpen && (
+        <S.CommLayer>
+          <S.ModalContainer width={modalWidth}>
+            {title && (
+              <S.HeaderLayer>
+                <Headline3>{title}</Headline3>
+                <S.ModalDivider color="black" />
+              </S.HeaderLayer>
+            )}
+            <S.StyledIconButton
+              icon={<CloseIcon />}
+              fillColor={theme.darkGray}
+              color={ButtonColor.TRANSPARENT}
+              onClick={handleModal}
+            />
+            {/*
+              본문에 나올 컴포넌트 혹은 string을 contents에 넣어주시면 됩니다
+             */}
+            <S.BodyLayer>
+              {typeof contents === 'string' && (
+                <S.BodyText>{contents}</S.BodyText>
+              )}
+              {typeof contents !== 'string' && <div>{contents}</div>}
+            </S.BodyLayer>
+            <S.FooterLayer>
+              {/* successText 정의 시 추가되는 버튼입니다.
+                기본적으로 클릭시 모달이 닫히는 모션이 들어갑니다.
+                onSuccess 정의 시 클릭 이벤트 변경이 가능합니다.
+              */}
+              {successText && (
+                <StyledButton
+                  type="button"
+                  fill={true}
+                  isMargin={false}
+                  onClick={onSuccess === undefined ? handleModal : onSuccess}
+                >
+                  {successText}
+                </StyledButton>
+              )}
+              {/* successText 정의 시 추가되는 버튼입니다.
+                기본적으로 클릭시 모달이 닫히는 모션이 들어갑니다.
+                onSuccess 정의 시 클릭 이벤트 변경이 가능합니다.
+              */}
+              {cancelText && (
+                <StyledButton
+                  type="button"
+                  fill={true}
+                  isMargin={false}
+                  onClick={onCancel === undefined ? handleModal : onCancel}
+                >
+                  {cancelText}
+                </StyledButton>
+              )}
+            </S.FooterLayer>
+          </S.ModalContainer>
+        </S.CommLayer>
+      )}
+    </>
+  );
+};
+
+export default Modal;

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 export interface GalleryProps {
   img: string;
 }
@@ -32,4 +34,19 @@ export interface OrderInfoProps {
     price: string;
     payment_method: string;
   }[];
+}
+
+export interface ModalProps {
+  opener: ReactNode;
+  title?: string;
+  contents: ReactNode | string;
+  successText?: string;
+  cancelText?: string;
+  modalWidth?: string;
+  onSuccess?: (() => void) | undefined;
+  onCancel?: (() => void) | undefined;
+}
+
+export interface ModalSizeProps {
+  width?: string;
 }


### PR DESCRIPTION
## 🚀 Ticket
- name :  <기본구조> 레이아웃 구현
- task : 모달 구현 완

<br />

## 🐝 Issue
- 모달의 구현이 완료되었습니다 두둥탁.. 그동안 모달이 없어 작업에 어려움을 겪었던 분들은 이제.. 삽가능..
- 경우의 수를 고려하여 작업을 하긴 하였으나,, 작업하다 모자란 부분이 있다면 contact me plz..!
- merge는 월요일 3시 이후에 진행시키겠읍니다 ^.~
- Props의 목록은 아래와 같습니다! 
  - opener : 모달을 열기 위한 버튼을 정의합니다.
  - title : 모달의 타이틀을 정의합니다. (optional)
  - contents : 모달의 컨텐츠를 정의합니다.
  - modalWidth : 모달의 넓이를 정의합니다 (optional)
  - successText/cancelText : 수행/취소 button의 텍스트를 정의합니다.(optional)
  - onSuccess/onCancel: success buttond의 클릭 이벤트를 정의합니다.(optional)


