### PR TITLE
[ADD] <상품 상세> 페이지 레이아웃

### DIFF
--- a/src/components/Review.tsx
+++ b/src/components/Review.tsx
@@ -1,9 +1,0 @@
-import React, { FC } from 'react';
-import { Reply } from '@class101/ui';
-
-const Review: FC = () => {
-  return <div>dfdf</div>;
-  // <Reply name="asdf*****" content="다 비키세요 더우니까" />;
-};
-
-export default Review;

--- a/src/pages/ProductDetail/ProductDetail.style.ts
+++ b/src/pages/ProductDetail/ProductDetail.style.ts
@@ -1,47 +1,35 @@
-import styled, { css } from 'styled-components';
-import { Button, Colors, Input } from '@class101/ui';
+import styled from 'styled-components';
+import { Button, CheckCircleIcon, Colors, Divider } from '@class101/ui';
+import { PageContainer } from '../../Styles/common.style';
+import { SelectColorProps } from '../../types/components';
+import { theme } from '../../Styles/theme';
 
-interface Props {
-  marginBottom?: string;
-  color?: string;
-  border?: string;
-}
-
-export const inputCommomStyle = {
-  backgroundColor: `${Colors.gray400}`,
-  borderColor: `${css`
-    &:hover {
-      ${Colors.red500};
-    }
-  `}`
-};
-
-export const ProductDetail = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100vw;
+export const ProductDetail = styled(PageContainer)`
+  ${({ theme }) => theme.flexBox(undefined, 'center', 'column')}
 `;
 
-export const ProductDetailUpperContainer = styled.section`
-  display: flex;
-  flex-direction: row;
-  width: 85%;
-  padding-bottom: 5rem;
-  border-bottom: 1px solid ${Colors.gray400};
+export const ProductDetailUpperContainer = styled.article`
+  ${({ theme }) => theme.flexBox(undefined, undefined, 'row')}
+  width: 100%;
+  height: 38rem;
+  padding-bottom: 3rem;
+  border-bottom: 1px solid ${theme.gray};
 `;
 
-export const ProductDetailLowerContainer = styled.section`
-  width: 85%;
+export const StyledDivider = styled(Divider)`
+  padding: 3rem 0;
+`;
+
+export const ProductDetailLowerContainer = styled.article`
+  width: 100%;
   padding-top: 3rem;
 `;
 
 export const ProductDetailImgWrap = styled.section`
-  display: flex;
-  flex-direction: row;
+  ${({ theme }) => theme.flexBox(undefined, undefined, 'row')}
   gap: 1.4rem;
-  width: calc(100% - 456px);
-  padding: 2rem;
+  width: 60%;
+  padding: 0 3rem 3rem;
 `;
 
 export const SubImgGroup = styled.div`
@@ -68,9 +56,8 @@ export const SubImg = styled.button`
 `;
 
 export const MainImgGroup = styled.div`
-  width: 535px;
-  max-width: 535px;
-  max-height: 669px;
+  width: 30rem;
+  height: 100%;
 `;
 
 export const MainImgBox = styled.div`
@@ -86,12 +73,9 @@ export const MainImg = styled.img`
 `;
 
 export const ProductDetailWrap = styled.section`
-  width: 456px;
-  padding: 2rem;
-`;
-
-export const ProductDetailGroup = styled.p<Props>`
-  margin-bottom: ${({ marginBottom }) => marginBottom};
+  ${({ theme }) => theme.flexBox('space-between', undefined, 'column')}
+  width: 40%;
+  padding: 0 3rem 3rem;
 `;
 
 export const ProductName = styled.h3`
@@ -114,16 +98,17 @@ export const Price = styled.div`
 `;
 
 export const SelectColorList = styled.ul`
-  display: flex;
+  ${({ theme }) => theme.flexBox(undefined, undefined, undefined)}
+  width: 70%;
   padding: 0;
   margin: 0.5rem 0;
   list-style: none;
 `;
 
-export const SelectColorBtn = styled.button<Props>`
-  width: 1.5rem;
-  height: 1.5rem;
-  margin-right: 1rem;
+export const SelectColorBtn = styled.button<SelectColorProps>`
+  width: 23px;
+  height: 23px;
+  margin-right: 0.9rem;
   background-color: ${({ color }) => color};
   border: ${props =>
     props.color === Colors.white ? '1px solid black' : 'none'};
@@ -134,8 +119,21 @@ export const SelectColorBtn = styled.button<Props>`
   }
 `;
 
+export const CheckedColorBtn = styled(CheckCircleIcon)<SelectColorProps>`
+  width: 23px;
+  height: 23px;
+  margin-right: 0.9rem;
+  border: ${props =>
+    props.color === Colors.white ? '1px solid black' : 'none'};
+  border-radius: 50%;
+
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
 export const SelectSizeList = styled.ul`
-  display: flex;
+  ${({ theme }) => theme.flexBox(undefined, undefined, undefined)}
   flex-wrap: wrap;
   padding: 0;
   margin: 0.5rem 0;
@@ -147,7 +145,7 @@ export const SelectSizeBtn = styled(Button)`
 `;
 
 export const AddCartBtn = styled(Button)`
-  width: 92%;
+  width: 100%;
   height: 3.8rem;
   background-color: ${Colors.black};
   border-radius: 2rem;
@@ -160,11 +158,28 @@ export const AddCartBtn = styled(Button)`
   }
 `;
 
-export const ReviewForm = styled.form`
-  display: flex;
-  justify-content: space-between;
+export const ReviewTitle = styled.h5`
+  margin-bottom: 1rem;
+  font-weight: bold;
 `;
 
-export const ReviewInput = styled(Input)`
-  width: 99%;
+export const ReviewForm = styled.form`
+  margin-bottom: 3rem;
+`;
+
+export const AddReviewGroup = styled.div`
+  ${({ theme }) => theme.flexBox('space-between', undefined, undefined)}
+`;
+
+export const ShowMoreReview = styled(Button)`
+  height: auto;
+  padding: 0;
+  background: none;
+  border: none;
+  text-decoration: underline;
+  color: ${theme.darkGray};
+
+  &:hover {
+    background: none;
+  }
 `;

--- a/src/pages/ProductDetail/ProductDetail.tsx
+++ b/src/pages/ProductDetail/ProductDetail.tsx
@@ -1,13 +1,20 @@
 import React, { FC } from 'react';
 import * as S from './ProductDetail.style';
 import {
-  Button,
   ButtonSize,
+  CheckCircleIcon,
   Colors,
-  Icon,
-  Input,
-  ModalBottomSheet
+  StarOutlineIcon,
+  StarIcon,
+  Reply,
+  EditOutlineIcon,
+  ReplySize,
+  TrashIcon,
+  ButtonIconPosition
 } from '@class101/ui';
+import Modal from '../../components/Modal/Modal';
+import { StyledButton, StyledInput } from '../../Styles/common.style';
+import { theme } from '../../Styles/theme';
 
 const ProductDetail: FC = () => {
   return (
@@ -38,24 +45,28 @@ const ProductDetail: FC = () => {
           </S.MainImgGroup>
         </S.ProductDetailImgWrap>
         <S.ProductDetailWrap>
-          <S.ProductDetailGroup marginBottom="3rem">
+          <p>
             <S.ProductName>나이키 에어 포스 1 '07</S.ProductName>
             <S.Category>여성 신발</S.Category>
             <S.Price>139,000 원</S.Price>
-          </S.ProductDetailGroup>
-          <S.ProductDetailGroup marginBottom="3rem">
+          </p>
+          <p>
             <S.Category>색상 선택</S.Category>
             <S.SelectColorList>
               {SELECT_COLOR.map(color => {
                 return (
                   <li key={color.id}>
                     <S.SelectColorBtn color={color.color} />
+                    {/* <S.CheckedColorBtn
+                      fillColor={color.color}
+                      color={color.color}
+                    /> */}
                   </li>
                 );
               })}
             </S.SelectColorList>
-          </S.ProductDetailGroup>
-          <S.ProductDetailGroup marginBottom="1rem">
+          </p>
+          <p>
             <S.Category>사이즈 선택</S.Category>
             <S.SelectSizeList>
               {SELECT_SIZE.map(size => {
@@ -66,59 +77,115 @@ const ProductDetail: FC = () => {
                 );
               })}
             </S.SelectSizeList>
-          </S.ProductDetailGroup>
-          <ModalBottomSheet
+          </p>
+          <Modal
             opener={<S.AddCartBtn>장바구니</S.AddCartBtn>}
-            title="장바구니에 담겼습니다."
-            subTitle=" "
+            contents="장바구니에 담겼습니다"
             successText="확인"
           />
-          {/* <S.AddCartBtn>장바구니</S.AddCartBtn> */}
         </S.ProductDetailWrap>
       </S.ProductDetailUpperContainer>
+      {/* <S.StyledDivider color={theme.gray} /> */}
       <S.ProductDetailLowerContainer>
-        <h5>리뷰(3.5/5.0)</h5>
-        {/* 벌점 선택 시 <Icon.Star /> */}
-        <Icon.StarOutline />
-        <Icon.StarOutline />
-        <Icon.StarOutline />
-        <Icon.StarOutline />
-        <Icon.StarOutline />
+        <S.ReviewTitle>리뷰(3.5/5.0)</S.ReviewTitle>
         <S.ReviewForm>
-          <Input className="styled input" inputStyle={S.inputCommomStyle} />
-          <Button type="submit" size={ButtonSize.LARGE}>
-            등록
-          </Button>
+          <div>
+            <StarOutlineIcon />
+            <StarOutlineIcon />
+            <StarOutlineIcon />
+            <StarOutlineIcon />
+            <StarOutlineIcon />
+          </div>
+          <S.AddReviewGroup>
+            <StyledInput width="99%" />
+            <StyledButton
+              type="submit"
+              size={ButtonSize.LARGE}
+              isMargin={false}
+            >
+              등록
+            </StyledButton>
+          </S.AddReviewGroup>
         </S.ReviewForm>
-        {/* <p>
-          <div>
-            <span>asdf******</span>
-            <span>(수정됨)</span>
-            <button>수정</button>
-            <button>삭제</button>
-            <span>2023.08.02</span>
-          </div>
-          <div>
-            <Icon.StarOutline />
-            <Icon.StarOutline />
-            <Icon.StarOutline />
-            <Icon.Star />
-            <Icon.Star />
-          </div>
-          <div>이 제품은 결국 반품했네요...</div>
-          <form>
-            <div>
-              <Icon.StarOutline />
-              <Icon.StarOutline />
-              <Icon.StarOutline />
-              <Icon.StarOutline />
-              <Icon.StarOutline />
-            </div>
-            <input placeholder="댓글 수정" />
-            <button type="submit">수정</button>
-            <button>취소</button>
-          </form>
-        </p> */}
+        <ul>
+          <li>
+            <Reply
+              name="AfterWe"
+              //댓글이 길어질 경우 다 보여줄 것인가
+              disableLineClamp={false}
+              readMoreText="전체보기"
+              hideText="숨기기"
+              hideReadMore={false}
+              //대댓글 보여줄 것인지
+              showChildren={false}
+              size={ReplySize.LARGE}
+              width="100%"
+              //댓글 수정 후 보여줄 텍스트
+              //nameDescription="수정됨"
+              nameDescriptionColor={theme.darkGray}
+              content={
+                <div>
+                  <div>
+                    <StarIcon size={16} />
+                    <StarIcon size={16} />
+                    <StarIcon size={16} />
+                    <StarOutlineIcon size={16} />
+                    <StarOutlineIcon size={16} />
+                  </div>
+                  댓글내용 댓글내용 댓글내용 댓글내용 댓글내용 댓글내용 댓글내용
+                  댓글내용 댓글내용 댓글내용 댓글내용 댓글내용 댓글내용 댓글내용
+                  댓글내용 댓글내용 댓글내용 댓글내용 댓글내용 댓글내용 댓글내용
+                  댓글내용 댓글내용 댓글내용 댓글내용 댓글내용 댓글내용 댓글내용
+                </div>
+                // 수정하기 버튼 클릭 시 생기는 input
+                // <S.ReviewForm>
+                //   <div>
+                //     <StarOutlineIcon />
+                //     <StarOutlineIcon />
+                //     <StarOutlineIcon />
+                //     <StarOutlineIcon />
+                //     <StarOutlineIcon />
+                //   </div>
+                //   <S.AddReviewGroup>
+                //     <StyledInput width="99%" />
+                //     <StyledButton
+                //       type="submit"
+                //       size={ButtonSize.LARGE}
+                //       isMargin={false}
+                //     >
+                //       등록
+                //     </StyledButton>
+                //   </S.AddReviewGroup>
+                // </S.ReviewForm>
+              }
+              timeText="업로드 시간"
+              rightAction={[
+                <Modal
+                  key="1"
+                  opener={
+                    <Reply.Action
+                      icon={<TrashIcon />}
+                      position={ButtonIconPosition.RIGHT}
+                      hidden={false}
+                    />
+                  }
+                  contents="댓글을 삭제 하시겠습니까?"
+                  successText="확인"
+                  cancelText="취소"
+                />,
+                <Reply.Action
+                  key="2"
+                  icon={<EditOutlineIcon />}
+                  //수정하기 버튼 클릭 시 input창으로 바뀌는 로직
+                  //onClick={() => {}}
+                  position={ButtonIconPosition.LEFT}
+                  hidden={false}
+                />
+              ]}
+            />
+          </li>
+        </ul>
+        <S.ShowMoreReview>리뷰 더보기</S.ShowMoreReview>
       </S.ProductDetailLowerContainer>
     </S.ProductDetail>
   );

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -71,3 +71,7 @@ export interface PaymentInformProps {
   delieveryFee: string;
   totalPaymentAmount: string;
 }
+
+export interface SelectColorProps {
+  color: string;
+}


### PR DESCRIPTION
## 🚀 Ticket
- name :  <상품 상세> 페이지 
- task : 레이아웃

<br />

## 🐝 Issue
- 컬러 버튼 클릭 시 check circle 아이콘이 흰색은 체크 표시가 안보임 & 체크 전 후 circle 크기가 묘하게 달라 다른 방법을 생각 중입니다.
- Divider 적용했는데 출력이 안돼서, 현재 위쪽 article(ProductDetailUpperContainer 컴포넌트)에 border bottom을 준 상태입니다. 이유가 뭘까요..
- 리뷰 작성하는 input 스타일이 작성된 리뷰와 어울리지 않아 수정하려고 합니다. 좋은 아이디어 있으면 언제나 대환영!
- 리뷰의 nameDescription은 원래 직함을 적는 란인데 우리 디자인에 따라 ‘수정됨’ 삽입했습니다.
- 리뷰 수정 버튼 클릭 시 input창으로 변경되는 로직 구현은 기능이라 생각해 작성하지 않았습니다. 이거 제가 하는거면 말해주세요!


